### PR TITLE
Feature(#6): Icon color and size configurable by css

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,9 +24,41 @@
       <h3>fa-icon demo</h3>
       <demo-snippet>
         <template>
-          <fa-icon path-prefix="../node_modules" class="fab fa-google" size="24"></fa-icon>
-          <fa-icon path-prefix="../node_modules" class="fab fa-twitch" size="24"></fa-icon>
-          <fa-icon path-prefix="../node_modules" class="fab fa-linkedin" size="24"></fa-icon>
+          <fa-icon path-prefix="../node_modules" color="#4285F4" class="fab fa-google" size="24"></fa-icon>
+          <fa-icon path-prefix="../node_modules" color="#8c45f7" class="fab fa-twitch" size="24"></fa-icon>
+          <fa-icon path-prefix="../node_modules" color="#0077b5" class="fab fa-linkedin" size="24"></fa-icon>
+        </template>
+      </demo-snippet>
+    </div>
+    <div class="vertical-section-container centered">
+      <h3>Styling trough CSS</h3>
+      <demo-snippet>
+        <template>
+          <fa-icon id="GoogleIcon" path-prefix="../node_modules" class="fab fa-google"></fa-icon>
+          <fa-icon id="TwitchIcon" path-prefix="../node_modules" class="fab fa-twitch"></fa-icon>
+          <fa-icon id="LinkedinIcon" path-prefix="../node_modules" class="fab fa-linkedin"></fa-icon>
+          <style>
+            #GoogleIcon {
+              /*
+              * Using color property
+              */
+              color: #4285F4;
+            }
+            #TwitchIcon {
+              /*
+              * Using custom properties to pass the color to the element
+              */
+              --fa-icon-fill-color: #8c45f7;
+            }
+            #LinkedinIcon {
+              /*
+              * Changing width and height trough custom properties
+              */
+              --fa-icon-width: 3rem;
+              --fa-icon-height: 3rem;
+              color: #0077b5;
+            }
+          </style>
         </template>
       </demo-snippet>
     </div>

--- a/fa-icon.js
+++ b/fa-icon.js
@@ -18,6 +18,11 @@ class FaIcon extends LitElement {
         padding: 0;
         margin: 0;
       }
+      :host svg {
+        fill: var(--fa-icon-fill-color, currentcolor);
+        width: var(--fa-icon-width, 19px);
+        height: var(--fa-icon-height, 19px);
+      }
     `;
   }
 
@@ -45,23 +50,29 @@ class FaIcon extends LitElement {
     this.iClass = "";
     this.src = "";
     this.style = "";
-    this.size = "19";
-    this.color = "#000";
+    this.size = "";
+    this.color = "";
     this.pathPrefix = "node_modules";
   }
   firstUpdated() {
     this.src = this.getSources(this.iClass);
   }
+  _parseStyles() {
+    return `
+      ${this.size ? `width: ${this.size};` : ''}
+      ${this.size ? `height: ${this.size};` : ''}
+      ${this.color ? `fill: ${this.color};` : ''}
+      ${this.style}
+    `;
+  }
   render() {
     return html`
-      <div class="fa-icon ${this.iClass}">
-        <svg
-          style=" width:${this.size};  height: ${this.size}; fill: ${this
-            .color}; ${this.style}"
-        >
-          <use href="${this.src}"></use>
-        </svg>
-      </div>
+      <svg 
+        .style="${this._parseStyles()}">
+        <use 
+          href="${this.src}">
+        </use>
+      </svg>
     `;
   }
 }

--- a/test/fa-icon_test.html
+++ b/test/fa-icon_test.html
@@ -36,14 +36,8 @@
           assert.equal(element.iClass, '');
           assert.equal(element.src, '');
           assert.equal(element.style, '');
-        });
-
-        test('element default size should be 19', () => {
-          assert.equal(element.size, '19');
-        });
-
-        test('element default color is #000', () => {
-          assert.equal(element.color, '#000');
+          assert.equal(element.size, '');
+          assert.equal(element.color, '');
         });
 
         test('element default path prefix is node_modules', () => {


### PR DESCRIPTION
This pull request implements the necessary changes for the component to be flexible to CSS styles. 

What changed?:

- Removed default size and color from properties.
- Implemented CSS custom properties to handle component styles.
- Updated unit tests to match new changes.

**NOTE:** This pull request contains a MINOR change, since old component instances will still work if using attributes (`<component color="red">`)